### PR TITLE
fix: mypage auth flash

### DIFF
--- a/src/app/member/layout.jsx
+++ b/src/app/member/layout.jsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useUser } from '@/contexts/user';
+import Breadcrumb from '@/components/common/Breadcrumb';
+import PageTitle from '@/components/common/PageTitle';
+
+export default function MemberLayout({ children }) {
+  const router = useRouter();
+  const { user, loading } = useUser();
+
+  // Redirect to login if not authenticated
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push('/login');
+    }
+  }, [user, loading, router]);
+
+  // Show loading state while checking authentication
+  if (loading) {
+    return (
+      <main className='l-container'>
+      {/* <Metadata title={METADATA.LOGIN} /> */}
+      <Breadcrumb paths={[{ label: 'ログイン' }]} />
+      <PageTitle title='ログイン' subTitle='Login' />
+      <div className='l-container--small l-container--contents'>
+        <div className='flex min-h-screen flex-col items-center justify-between p-24'>
+            <div>Loading...</div>
+        </div>
+      </div>
+    </main>
+    );
+  }
+
+  // Don't render content if user is not authenticated
+  // (will be redirected to login page)
+  if (!user) {
+    return null;
+  }
+
+  // Render children only if authenticated
+  return <>{children}</>;
+}

--- a/src/app/member/mypage/page.jsx
+++ b/src/app/member/mypage/page.jsx
@@ -12,14 +12,26 @@ import { useEffect, useState } from 'react';
 import Metadata from '@/components/common/Metadata';
 import { METADATA } from '@/constants/config';
 import { useRouter } from 'next/navigation';
+import { useUser } from '@/contexts/user';
 
 export default function Page() {
   const [myFavorites, setMyFavorites] = useState([]);
   // const [setMyFavoritesPageInfo] = useState([]);
   const [limitedContent, setLimitedContent] = useState([]);
   const router = useRouter();
+  const { user, loading } = useUser();
+
+  // Redirect to login if not authenticated
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push('/login');
+    }
+  }, [user, loading, router]);
 
   useEffect(() => {
+    // Only fetch data if user is authenticated
+    if (!user) return;
+
     const favoriteList = async () => {
       try {
         const favorites = await getMyFavoriteList();
@@ -34,9 +46,12 @@ export default function Page() {
       }
     };
     favoriteList();
-  }, []);
+  }, [user, router]);
 
   useEffect(() => {
+    // Only fetch data if user is authenticated
+    if (!user) return;
+
     const fetchMemberOnlyList = async () => {
       try {
         const limitedContent = await getLimitedContent();
@@ -47,7 +62,25 @@ export default function Page() {
     };
 
     fetchMemberOnlyList(); // Fetch member-only list initially
-  }, []);
+  }, [user]);
+
+  // Show loading state while checking authentication
+  if (loading) {
+    return (
+      <main className='l-container'>
+        <Metadata title={METADATA.MEMBER_MYPAGE} />
+        <div className='flex min-h-screen items-center justify-center'>
+          <div>Loading...</div>
+        </div>
+      </main>
+    );
+  }
+
+  // Don't render content if user is not authenticated
+  // (will be redirected to login page)
+  if (!user) {
+    return null;
+  }
 
   return (
     <main className='l-container'>

--- a/src/app/member/mypage/page.jsx
+++ b/src/app/member/mypage/page.jsx
@@ -12,26 +12,14 @@ import { useEffect, useState } from 'react';
 import Metadata from '@/components/common/Metadata';
 import { METADATA } from '@/constants/config';
 import { useRouter } from 'next/navigation';
-import { useUser } from '@/contexts/user';
 
 export default function Page() {
   const [myFavorites, setMyFavorites] = useState([]);
   // const [setMyFavoritesPageInfo] = useState([]);
   const [limitedContent, setLimitedContent] = useState([]);
   const router = useRouter();
-  const { user, loading } = useUser();
-
-  // Redirect to login if not authenticated
-  useEffect(() => {
-    if (!loading && !user) {
-      router.push('/login');
-    }
-  }, [user, loading, router]);
 
   useEffect(() => {
-    // Only fetch data if user is authenticated
-    if (!user) return;
-
     const favoriteList = async () => {
       try {
         const favorites = await getMyFavoriteList();
@@ -46,12 +34,9 @@ export default function Page() {
       }
     };
     favoriteList();
-  }, [user, router]);
+  }, []);
 
   useEffect(() => {
-    // Only fetch data if user is authenticated
-    if (!user) return;
-
     const fetchMemberOnlyList = async () => {
       try {
         const limitedContent = await getLimitedContent();
@@ -62,25 +47,7 @@ export default function Page() {
     };
 
     fetchMemberOnlyList(); // Fetch member-only list initially
-  }, [user]);
-
-  // Show loading state while checking authentication
-  if (loading) {
-    return (
-      <main className='l-container'>
-        <Metadata title={METADATA.MEMBER_MYPAGE} />
-        <div className='flex min-h-screen items-center justify-center'>
-          <div>Loading...</div>
-        </div>
-      </main>
-    );
-  }
-
-  // Don't render content if user is not authenticated
-  // (will be redirected to login page)
-  if (!user) {
-    return null;
-  }
+  }, []);
 
   return (
     <main className='l-container'>

--- a/src/app/member/mypage/page.jsx
+++ b/src/app/member/mypage/page.jsx
@@ -34,7 +34,7 @@ export default function Page() {
       }
     };
     favoriteList();
-  }, []);
+  }, [router]);
 
   useEffect(() => {
     const fetchMemberOnlyList = async () => {


### PR DESCRIPTION
  ## Summary
  Fix authentication flash issue on member mypage where content briefly appears before redirect when accessing
  without authentication.

  ## Problem
  When users click the login button and navigate to `/member/mypage`, the page content flashes briefly before being
  redirected. This happens because:
  1. Component renders immediately on navigation
  2. Authentication check runs in `useEffect` (after render)
  3. Content is visible during this gap
  4. Redirect happens after authentication check fails